### PR TITLE
Fix labs link on home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ hero:
       link: /installations/git
     - theme: alt
       text: Labs
-      link: /labs/lab01
+      link: /labs/lab-01
 
 features:
   - title: Installations


### PR DESCRIPTION
## Summary
- fix broken link to labs in docs index

## Testing
- `node docs/node_modules/vitepress/bin/vitepress.js build docs` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6863da63a68c832c9186585d6aea6176