### PR TITLE
Add VitePress custom theme

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -1,11 +1,15 @@
 import { defineConfig } from 'vitepress'
+import Theme from './theme'
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "Python Programming",
   description: "Course and Labs Informations",
   base: '/Python-Programming/',
+  theme: Theme,
   themeConfig: {
+    logo: '/assets/images/profile.jpeg',
+    heroImage: '/assets/images/profile.jpeg',
     // https://vitepress.dev/reference/default-theme-config
     nav: [
       { text: 'Home', link: '/' },

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,6 @@
+/* Custom theme overrides */
+:root {
+  --vp-c-brand: #34965a;
+  --vp-c-brand-light: #4dc38e;
+  --vp-c-brand-dark: #2a7647;
+}

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,0 +1,6 @@
+import DefaultTheme from 'vitepress/theme'
+import './custom.css'
+
+export default {
+  ...DefaultTheme,
+}


### PR DESCRIPTION
## Summary
- add a simple theme folder with CSS overrides
- import the theme in VitePress config
- set a logo/hero image

## Testing
- `npm run docs:build` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68648f897950832c9a267ebaf6adefe2