### PR TITLE
Add .gitignore for Node/Vite artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Node dependencies and cache
+.vitepress/
+docs/node_modules/
+docs/.vitepress/cache/
+
+# Build assets
+docs/assets/
+docs/.vitepress/dist/
+
+# Misc
+.DS_Store


### PR DESCRIPTION
## Summary
- add .gitignore to skip build files and node modules

## Testing
- `npm run docs:build --prefix docs` *(fails: vitepress permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68649d5957dc832ca3971d83cde2d4be