### PR TITLE
docs: restyle chapter 1 PDF button

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -2,3 +2,19 @@
   --vp-c-brand-1: #ff5722;
   --vp-font-family-base: 'Segoe UI', Roboto, sans-serif;
 }
+
+/* Style for lecture PDF buttons */
+.open-pdf-btn {
+  background-color: var(--vp-c-brand-1);
+  color: white;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  font-family: var(--vp-font-family-base);
+  transition: background-color 0.3s;
+}
+
+.open-pdf-btn:hover {
+  background-color: #e65100;
+}

--- a/docs/lectures/chapter-01.md
+++ b/docs/lectures/chapter-01.md
@@ -17,10 +17,7 @@ outline : deep
 <br>
 
 <a href="./chapter-01.pdf" target="_blank" rel="noopener">
-  <button 
-    style="background-color: #f57c00; color: white; padding: 10px 20px; border: none; border-radius: 5px; cursor: pointer;"
-    onmouseover="this.style.backgroundColor='#e65100'"
-    onmouseout="this.style.backgroundColor='#f57c00'">
+  <button class="open-pdf-btn">
     Open in full screen
   </button>
 </a>


### PR DESCRIPTION
## Summary
- restyle the PDF open button in chapter 1 to use theme fonts and colors
- add reusable `.open-pdf-btn` style
- docs build passes

## Testing
- `npm ci --prefix docs`
- `npm run docs:build --prefix docs`

------
https://chatgpt.com/codex/tasks/task_e_68661921d5a4832ca5680a455b7b4460