### PR TITLE
Improve sidebar active link highlight

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -18,3 +18,11 @@
 .open-pdf-btn:hover {
   background-color: #e65100;
 }
+
+/* Pill highlight for active sidebar link */
+.VPSidebarItem.is-active > .item .link > .text {
+  background-color: var(--vp-c-brand-1);
+  color: #ffffff;
+  border-radius: 9999px;
+  padding: 2px 10px;
+}


### PR DESCRIPTION
## Summary
- add pill-shaped highlight to active sidebar entry

## Testing
- `npm ci --prefix docs`
- `CI=true npm run docs:build --prefix docs`

------
https://chatgpt.com/codex/tasks/task_e_686cb6e89174832c9c8553c800e56074