### PR TITLE
Apply color themes to docs

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,6 +1,33 @@
 :root {
-  --vp-c-brand-1: #ff5722;
+  /* Light mode colors */
+  --vp-c-bg: #FFF3F8;          /* background */
+  --vp-c-bg-alt: #F9E7EF;      /* card surfaces */
+  --vp-c-bg-soft: #F9E7EF;
+
+  --vp-c-brand-1: #FF4F93;     /* primary accent */
+  --vp-c-brand-2: #FF4F93;
+  --vp-c-brand-3: #FF4F93;
+
+  --vp-c-text-1: #333333;      /* text */
+  --vp-c-text-2: #BFA7BC;      /* secondary text */
+  --vp-c-text-3: #BFA7BC;
+
   --vp-font-family-base: 'Segoe UI', Roboto, sans-serif;
+}
+
+/* Dark mode overrides */
+.dark {
+  --vp-c-bg: #121C32;
+  --vp-c-bg-alt: #283352;
+  --vp-c-bg-soft: #283352;
+
+  --vp-c-brand-1: #0A84FF;
+  --vp-c-brand-2: #0A84FF;
+  --vp-c-brand-3: #0A84FF;
+
+  --vp-c-text-1: #E7E7E7;
+  --vp-c-text-2: #5D6B89;
+  --vp-c-text-3: #5D6B89;
 }
 
 /* Style for lecture PDF buttons */


### PR DESCRIPTION
## Summary
- tweak `custom.css` with new dark/light color variables

## Testing
- `npm ci --prefix docs`
- `node docs/node_modules/vitepress/bin/vitepress.js build docs`

------
https://chatgpt.com/codex/tasks/task_e_6874d0b3960c832c8c4b4de3c2f9e74a